### PR TITLE
Allow custom configuration of permission notification properties

### DIFF
--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -47,7 +47,7 @@ public class NotificationService {
                 .setContentText(message)
                 .setAutoCancel(true)
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setSmallIcon(android.R.mipmap.sym_def_app_icon)
+                .setSmallIcon(R.mipmap.android_permissions_notification_small_icon)
                 .setContentIntent(pendingIntent);
 
         notificationBuilder.setDeleteIntent(deleteIntent);

--- a/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
+++ b/src/main/java/com/intentfilter/androidpermissions/services/NotificationService.java
@@ -6,10 +6,13 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Build;
-import androidx.core.app.NotificationCompat;
 
 import com.intentfilter.androidpermissions.R;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 
 import static android.app.PendingIntent.FLAG_ONE_SHOT;
 import static android.content.Context.NOTIFICATION_SERVICE;
@@ -49,6 +52,14 @@ public class NotificationService {
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setSmallIcon(R.mipmap.android_permissions_notification_small_icon)
                 .setContentIntent(pendingIntent);
+
+        // set color if it has been configured
+        try {
+            int notificationColor = ContextCompat.getColor(context, R.color.android_permissions_notification_color);
+            notificationBuilder.setColor(notificationColor);
+        } catch (Resources.NotFoundException e) {
+            // resource alias has not been overridden - use default notification color
+        }
 
         notificationBuilder.setDeleteIntent(deleteIntent);
 

--- a/src/main/res/values/drawable_aliases.xml
+++ b/src/main/res/values/drawable_aliases.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <mipmap name="android_permissions_notification_small_icon">@android:mipmap/sym_def_app_icon</mipmap>
+</resources>

--- a/src/main/res/values/drawable_aliases.xml
+++ b/src/main/res/values/drawable_aliases.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <mipmap name="android_permissions_notification_small_icon">@android:mipmap/sym_def_app_icon</mipmap>
+    <color name="android_permissions_notification_color">@null</color>
 </resources>


### PR DESCRIPTION
Introduce default properties for the permission notification icon and color that can be overridden by the project using this library.

Defaults are left as per the original source code so as not to introduce unexpected results in existing users.